### PR TITLE
Change regex to only replace comments if the // is at the start of th…

### DIFF
--- a/src/app/twig.service.ts
+++ b/src/app/twig.service.ts
@@ -24,7 +24,7 @@ export class TwigService {
     try {
       if (json) {
         if (json.includes('//')) {
-          json = json.replace(/(?:(,\s*?)\n\s*?)?\/\/[^\n]*?(?=\n|$)/g, '$1');
+          json = json.replace(/(?:^|\n)\s*?\/\/.+?(?:\n|$)/g, '');
         }
 
         data = JSON.parse(json);


### PR DESCRIPTION
…e line exlcuding indenting

This will fix the issue with json values containing a double slash from breaking the json.