### PR TITLE
Fix commenting out lines with existing double slashes

### DIFF
--- a/src/app/editor/editor.component.ts
+++ b/src/app/editor/editor.component.ts
@@ -367,8 +367,8 @@ export class EditorComponent implements OnInit, OnChanges {
 
     for (let key in lines) {
 
-      if (lines[key].includes('//')) {
-        lines[key] = lines[key].replace(/\/\/ ?/, '')
+      if (lines[key].includes('//') && lines[key].match(/^\s*?\/\/ /)) {
+        lines[key] = lines[key].replace(/^(\s*?)\/\/ /, '$1');
         charsAdded += -3;
       } else {
         let index = 0;


### PR DESCRIPTION
This will fix the issue occurring when using the shortcut to comment out a line that has double slashes somewhere in the line that removed the double slashes instead of adding a comment at the start of the line.